### PR TITLE
Update RenderNode and RenderIndex specs for versioning/diffing

### DIFF
--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
@@ -12,7 +12,8 @@
                 "type": "object",
                 "required": [
                     "schemaVersion",
-                    "interfaceLanguages"
+                    "interfaceLanguages",
+                    "metadata"
                 ],
                 "properties": {
                     "identifier": {
@@ -24,6 +25,31 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/components/schemas/Node"
+                            }
+                        }
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "properties": {
+                            "version": {
+                                "$ref" : "#/components/schemas/Version"
+                            }
+                        }
+                    },
+                    "versions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/VersionPatch"
+                        }
+                    },
+                    "versionDifferences": {
+                        "description": "A dictionary property that maps from a node identifier to a dictionary of diffs for that node. The node diffs dictionary maps from a version to the type of change (modified/added) the current node should display when diffing against that prior version. If nothing changed against a given version, that version won't appear in the dictionary of diffs.",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string",
+                                "enum": ["modified", "added"]
                             }
                         }
                     }
@@ -120,7 +146,92 @@
                         "type": "integer"
                     }
                 }
-            }
+            },
+            "JSONPatch": {
+                "type": "array",
+                "items": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "required": [
+                                "op",
+                                "path",
+                                "value"
+                            ],
+                            "properties": {
+                                "op": {
+                                    "type": "string",
+                                    "enum": ["add", "test"]
+                                },
+                                "path": {
+                                    "type": "string"
+                                },
+                                "value": {}
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "required": [
+                                "op",
+                                "path"
+                            ],
+                            "properties": {
+                                "op": {
+                                    "type": "string",
+                                    "enum": ["remove"]
+                                },
+                                "path": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "required": [
+                                "op",
+                                "path",
+                                "from"
+                            ],
+                            "properties": {
+                                "op": {
+                                    "type": "string",
+                                    "enum": ["move", "copy"]
+                                },
+                                "path": {
+                                    "type": "string"
+                                },
+                                "from": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "VersionPatch": {
+                 "type": "object",
+                 "required": ["version"],
+                 "properties": {
+                     "version": {
+                         "$ref" : "#/components/schemas/Version"
+                     },
+                     "patch": {
+                         "$ref": "#/components/schemas/JSONPatch"
+                     }
+                 }
+             },
+             "Version": {
+                 "type": "object",
+                 "required": ["identifier", "displayName"],
+                 "properties": {
+                     "identifier": {
+                         "type": "string"
+                     },
+                     "displayName": {
+                         "type": "string"
+                     }
+                 }
+             },
         },
         "requestBodies": {},
         "securitySchemes": {},

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -1623,12 +1623,16 @@
             },
             "TutorialsMetadata": {
                 "type": "object",
+                "required": ["version"],
                 "properties": {
                     "category": {
                         "type": "string"
                     },
                     "categoryPathComponent": {
                         "type": "string"
+                    },
+                    "version": {
+                        "$ref" : "#/components/schemas/Version"
                     }
                 }
             },
@@ -1870,6 +1874,12 @@
                         "items": {
                             "$ref": "#/components/schemas/VariantOverride"
                         }
+                    },
+                    "versions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/VersionPatch"
+                        }
                     }
                 }
             },
@@ -1993,7 +2003,8 @@
             },
             "DocumentationMetadata": {
                 "required": [
-                    "title"
+                    "title",
+                    "version"
                 ],
                 "type": "object",
                 "properties": {
@@ -2053,6 +2064,9 @@
                         "items": {
                             "$ref": "#/components/schemas/SymbolTag"
                         }
+                    },
+                    "version": {
+                        "$ref" : "#/components/schemas/Version"
                     }
                 }
             },
@@ -2854,6 +2868,33 @@
                         "items": {
                             "type": "string"
                         }
+                    }
+                }
+            },
+            "VersionPatch": {
+                "type": "object",
+                "required": ["version"],
+                "properties": {
+                    "version": {
+                        "$ref" : "#/components/schemas/Version"
+                    },
+                    "patch": {
+                        "$ref": "#/components/schemas/JSONPatch"
+                    }
+                }
+            },
+            "Version": {
+                "type": "object",
+                "required": ["identifier", "displayName", "nodeHash"],
+                "properties": {
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "displayName": {
+                        "type": "string"
+                    },
+                    "nodeHash": {
+                        "type": "string"
                     }
                 }
             }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This updates the RenderNode spec for archive versioning using JSON Patches. It also updates the RenderIndex spec for versioning using JSON Patches, as diffing using a dictionary that maps from all previous versions of a given Node to what type of change should be displayed (such as “modified,” or “added”) when diffing between the current version and each past version.

## Testing

Copy and paste each spec into an OpenAPI spec validator.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [n/a?] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [n/a] Updated documentation if necessary
