### PR TITLE
Update the RenderIndex.spec.json to include patches and node modifica…

### DIFF
--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
@@ -26,6 +26,12 @@
                                 "$ref": "#/components/schemas/Node"
                             }
                         }
+                    },
+                    "versions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/VersionPatch"
+                        }
                     }
                 }
             },
@@ -99,6 +105,16 @@
                         "items": {
                             "$ref": "#/components/schemas/Node"
                         }
+                    },
+                    "diffs": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "enum": [
+                                "modified",
+                                "added"
+                            ]
+                        },
                     }
                 }
             },
@@ -120,7 +136,95 @@
                         "type": "integer"
                     }
                 }
-            }
+            },
+            "JSONPatch": {
+                "type": "array",
+                "items": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "required": [
+                                "op",
+                                "path",
+                                "value"
+                            ],
+                            "properties": {
+                                "op": {
+                                    "type": "string",
+                                    "enum": ["add", "test"]
+                                },
+                                "path": {
+                                    "type": "string"
+                                },
+                                "value": {}
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "required": [
+                                "op",
+                                "path"
+                            ],
+                            "properties": {
+                                "op": {
+                                    "type": "string",
+                                    "enum": ["remove"]
+                                },
+                                "path": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "required": [
+                                "op",
+                                "path",
+                                "from"
+                            ],
+                            "properties": {
+                                "op": {
+                                    "type": "string",
+                                    "enum": ["move", "copy"]
+                                },
+                                "path": {
+                                    "type": "string"
+                                },
+                                "from": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "VersionPatch": {
+                 "type": "object",
+                 "required": ["version"],
+                 "properties": {
+                     "version": {
+                         "$ref" : "#/components/schemas/Version"
+                     },
+                     "patch": {
+                         "$ref": "#/components/schemas/JSONPatch"
+                     }
+                 }
+             },
+             "Version": {
+                 "type": "object",
+                 "required": ["identifier", "displayName", "nodeContentHash"],
+                 "properties": {
+                     "identifier": {
+                         "type": "string"
+                     },
+                     "displayName": {
+                         "type": "string"
+                     },
+                     "nodeContentHash": {
+                         "type": "string"
+                     }
+                 }
+             }
         },
         "requestBodies": {},
         "securitySchemes": {},


### PR DESCRIPTION
## Summary

Adds versioning with the same JSON Patches that RenderNode.spec.json uses. Also adds diffing data to each Node via a dictionary that maps the string names of all previous versions of the Node to the type of change--i.e. “modified” or “added”.
## Dependencies

N/A.

## Testing

Copy and paste spec into an Open API spec validator.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [n/a] Added tests
- [n/a] Ran the `./bin/test` script and it succeeded
- [n/a] Updated documentation if necessary
